### PR TITLE
Fix GitHub Pages deployment workflow to use push to main instead of PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
 name: Deploy to GitHub Pages
 
 on:
-  pull_request:
+  # Trigger deployment only on pushes to the main branch
+  push:
     branches: [ main ]
-    types: [closed]
+  # Allow manual triggering
   workflow_dispatch:
 
 permissions:
@@ -17,12 +18,12 @@ concurrency:
 
 jobs:
   build:
-    # Only run when PR is merged, not when it's just closed without merging
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout main branch
         uses: actions/checkout@v4
+        with:
+          ref: main
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/GIT_WORKFLOW.md
+++ b/GIT_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Git Workflow for samuellimabraz.github.io
 
-This document outlines the Git workflow for this project, which follows a development branch strategy with PR-based deployments.
+This document outlines the Git workflow for this project, which follows a development branch strategy with main branch deployments.
 
 ## Branches
 
@@ -47,11 +47,20 @@ This document outlines the Git workflow for this project, which follows a develo
 
 ### Deploying to Production
 
-1. Create a PR from `develop` to `main` when you're ready to deploy.
+1. Create a PR from `develop` to `main` when you're ready to deploy:
+   ```bash
+   # From the develop branch
+   git checkout develop
+   git pull origin develop
+   
+   # Create a PR from develop to main using GitHub interface
+   ```
 
-2. After review, merge the PR into `main`.
+2. After review, merge the PR into `main` through the GitHub interface.
 
-3. The GitHub Actions workflow will automatically build and deploy your site to GitHub Pages.
+3. Once merged into `main`, the deployment workflow will automatically trigger and deploy your site to GitHub Pages.
+
+4. You can also trigger a manual deployment from the Actions tab if needed.
 
 ## CI/CD Pipelines
 
@@ -61,10 +70,20 @@ This project uses two GitHub Actions workflows:
    - Triggered on pushes and PRs to the `develop` branch
    - Builds the project to ensure there are no build errors
    - Does not deploy the site
+   - Allows you to test changes before promoting to production
 
 2. **Deploy to GitHub Pages** (`.github/workflows/deploy.yml`):
-   - Triggered when a PR to `main` is merged
+   - Triggered when changes are pushed to the `main` branch
+   - Always deploys from the `main` branch, never from `develop`
    - Builds the project and deploys it to GitHub Pages
+
+## GitHub Pages Configuration
+
+GitHub Pages for this repository is configured to:
+
+1. Deploy only from the `main` branch
+2. Use GitHub Actions as the deployment method
+3. Enforce environment protection rules on the `github-pages` environment
 
 ## Best Practices
 


### PR DESCRIPTION
This pull request updates the deployment workflow and documentation to streamline and clarify the process for deploying to GitHub Pages. The workflow now triggers deployments only on pushes to the `main` branch, and the documentation reflects these changes while providing additional guidance for manual deployments and best practices.

### Workflow Updates:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R7): Updated the deployment workflow to trigger only on `push` events to the `main` branch instead of on pull request closures. Added support for manual triggering using `workflow_dispatch`. Updated the `Checkout` step to explicitly check out the `main` branch. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R7) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L20-R26)

### Documentation Updates:
* [`GIT_WORKFLOW.md`](diffhunk://#diff-02daeb2a2c89fccdd4e0dfa763818d84b9b23f30c5fa15fd1cc7e347f096a98fL3-R3): Updated the Git workflow to reflect the new deployment strategy, emphasizing deployments from the `main` branch. Added detailed instructions for creating and merging pull requests from `develop` to `main`. Clarified the behavior of CI/CD pipelines and added a new section on GitHub Pages configuration, including environment protection rules. [[1]](diffhunk://#diff-02daeb2a2c89fccdd4e0dfa763818d84b9b23f30c5fa15fd1cc7e347f096a98fL3-R3) [[2]](diffhunk://#diff-02daeb2a2c89fccdd4e0dfa763818d84b9b23f30c5fa15fd1cc7e347f096a98fL50-R63) [[3]](diffhunk://#diff-02daeb2a2c89fccdd4e0dfa763818d84b9b23f30c5fa15fd1cc7e347f096a98fR73-R87)