### PR TITLE
fix: Update project image paths in projects.ts to use absolute URLs f…

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -76,10 +76,10 @@ export const projects: Project[] = [
     {
         id: "cafedl",
         title: "CafeDL: Deep Learning Framework",
-        description: "A Java‑based deep learning library built from scratch (inspired by Keras and “Deep Learning From Scratch”), featuring core layers (Conv2D, Dense, Dropout, etc.), activation/loss/optimizer modules, ND4J‑powered tensor operations, MongoDB persistence via Morphia, and a QuickDraw‑style sketch‑classification game using JavaFX and MVC.",
+        description: "A Java‑based deep learning library built from scratch (inspired by Keras and 'Deep Learning From Scratch'), featuring core layers (Conv2D, Dense, Dropout, etc.), activation/loss/optimizer modules, ND4J‑powered tensor operations, MongoDB persistence via Morphia, and a QuickDraw‑style sketch‑classification game using JavaFX and MVC.",
         tags: ["Java", "Deep Learning", "Framework", "Educational"],
         github: "https://github.com/samuellimabraz/cafedl",
-        image: "/assets/cafe-dl.png",
+        image: "https://raw.githubusercontent.com/samuellimabraz/samuellimabraz.github.io/refs/heads/main/assets/cafe-dl.png",
         featured: true,
         codeExamples: [
             {
@@ -115,7 +115,7 @@ export const projects: Project[] = [
         description: "ROS2 adaptation of the vision_to_mavros package that bridges visual pose estimation systems with flight controllers. Enables integration between Intel RealSense T265 tracking cameras and ArduPilot/PX4 via MAVROS with support for various mounting orientations.",
         tags: ["ROS2", "Robotics", "Drone", "Computer Vision", "ArduPilot", "RealSense"],
         github: "https://github.com/Black-Bee-Drones/vision_to_mavros",
-        image: "/assets/realsense-photo.jpg",
+        image: "https://raw.githubusercontent.com/samuellimabraz/samuellimabraz.github.io/refs/heads/main/assets/realsense-photo.jpg",
         featured: true,
         codeExamples: [
             {
@@ -143,7 +143,7 @@ export const projects: Project[] = [
         github: "https://github.com/samuellimabraz/OpenCVGUI",
         demo: "https://huggingface.co/spaces/samuellimabraz/opencv-gui",
         embedUrl: "https://samuellimabraz-opencv-gui.hf.space",
-        image: "/assets/opencv-gui-2.png",
+        image: "https://raw.githubusercontent.com/samuellimabraz/samuellimabraz.github.io/refs/heads/main/assets/opencv-gui-2.png",
         featured: true,
         codeExamples: [
             {
@@ -215,7 +215,7 @@ export const projects: Project[] = [
         description: "Generic, configurable PID controller implemented as a ROS2 node in C++. Designed for versatile control applications including line following, altitude control, position control, velocity control, and heading/yaw control.",
         tags: ["ROS2", "C++", "Control Systems", "Robotics", "Real-time"],
         github: "https://github.com/Black-Bee-Drones/pid-controller",
-        image: "/assets/pid.png",
+        image: "https://raw.githubusercontent.com/samuellimabraz/samuellimabraz.github.io/refs/heads/main/assets/pid.png",
         featured: true,
         codeExamples: [
             {
@@ -263,7 +263,7 @@ export const projects: Project[] = [
         tags: ["Computer Vision", "Hugging Face", "Open Source", "Community"],
         demo: "https://huggingface.co/spaces/samuellimabraz/cv-hangout",
         embedUrl: "https://samuellimabraz-cv-hangout.hf.space",
-        image: "/assets/hf-hangout.png",
+        image: "https://samuellimabraz.github.io/assets/hf-hangout.png",
         featured: true,
         codeExamples: [
             {
@@ -279,7 +279,7 @@ export const projects: Project[] = [
         description: "Scalable facial recognition system using DeepFace, FastAPI, and MongoDB Atlas Vector Search for efficient face matching and similarity search.",
         tags: ["Facial Recognition", "FastAPI", "MongoDB", "Vector Search"],
         github: "https://github.com/samuellimabraz/face-api",
-        image: "/assets/face-api.png",
+        image: "https://raw.githubusercontent.com/samuellimabraz/samuellimabraz.github.io/refs/heads/main/assets/face-api.png",
         featured: false,
         codeExamples: [
             {
@@ -336,7 +336,7 @@ export const projects: Project[] = [
         description: "Python application for real-time mouse control via hand gestures using OpenCV and Google MediaPipe for accessibility and hands-free computing.",
         tags: ["Computer Vision", "MediaPipe", "Python"],
         github: "https://github.com/samuellimabraz/HandMouseController",
-        image: "/assets/hand-controller.png",
+        image: "https://raw.githubusercontent.com/samuellimabraz/samuellimabraz.github.io/refs/heads/main/assets/hand-controller.png",
         featured: false,
         codeExamples: [
             {


### PR DESCRIPTION
This pull request updates the image URLs for projects in the `src/data/projects.ts` file to use absolute URLs pointing to the raw assets in the GitHub repository, instead of relative paths.

**Project asset URL updates:**

* Changed the `image` fields for multiple projects (e.g., "CafeDL", "vision_to_mavros", "OpenCVGUI", "pid-controller", "face-api", "HandMouseController") to use absolute URLs referencing images hosted on GitHub, ensuring that images load correctly regardless of deployment context. [[1]](diffhunk://#diff-1b4275a4da1837a927a436265aa968021d6e1ee7c53f4edb8b830a851c6b1935L79-R82) [[2]](diffhunk://#diff-1b4275a4da1837a927a436265aa968021d6e1ee7c53f4edb8b830a851c6b1935L118-R118) [[3]](diffhunk://#diff-1b4275a4da1837a927a436265aa968021d6e1ee7c53f4edb8b830a851c6b1935L146-R146) [[4]](diffhunk://#diff-1b4275a4da1837a927a436265aa968021d6e1ee7c53f4edb8b830a851c6b1935L218-R218) [[5]](diffhunk://#diff-1b4275a4da1837a927a436265aa968021d6e1ee7c53f4edb8b830a851c6b1935L282-R282) [[6]](diffhunk://#diff-1b4275a4da1837a927a436265aa968021d6e1ee7c53f4edb8b830a851c6b1935L339-R339)
* Updated the "cv-hangout" project to use an absolute image URL, but without the `/refs/heads/main/` path segment, matching a slightly different hosting convention.

**Content consistency:**

* Standardized the "CafeDL" project description to use single quotes instead of a Unicode hyphen for the phrase 'Deep Learning From Scratch'.